### PR TITLE
Adds a password generator to the record edit panel

### DIFF
--- a/pwa/src/lib/Dashboard.svelte
+++ b/pwa/src/lib/Dashboard.svelte
@@ -34,14 +34,8 @@
     let isDirty = false;
 
     let generator;
-    let genClickCount = 0;
     let showGenOptions = false;
 
-    function handleGenerate() {
-        genClickCount++;
-        generator.generate();
-        if (genClickCount >= 2) showGenOptions = true;
-    }
     let showModal = false;
     let modalConfig = {
         title: "",
@@ -172,7 +166,6 @@
             oldTitle = rec.Title; // Store original title
             showPassword = false;
             isNewRecord = false;
-            genClickCount = 0;
             showGenOptions = false;
         } catch (e) {
             console.error(e);
@@ -197,7 +190,6 @@
         oldTitle = "";
         showPassword = true;
         isNewRecord = true;
-        genClickCount = 0;
         showGenOptions = false;
     }
 
@@ -687,12 +679,17 @@
                         <button on:click={() => (showPassword = !showPassword)}>
                             {showPassword ? "Hide" : "Show"}
                         </button>
-                        <button class="generate-btn" on:click={handleGenerate}>
+                        <button class="generate-btn" on:click={() => generator.generate()}>
                             <span class="generate-text">Generate</span>
                             <svg class="generate-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <rect width="18" height="18" x="3" y="3" rx="2" ry="2"/>
                                 <path d="M16 8h.01"/><path d="M8 8h.01"/><path d="M8 16h.01"/>
                                 <path d="M16 16h.01"/><path d="M12 12h.01"/>
+                            </svg>
+                        </button>
+                        <button class="icon-btn" on:click={() => (showGenOptions = !showGenOptions)} title="Generator options">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
                             </svg>
                         </button>
                         <button

--- a/pwa/src/lib/Dashboard.svelte
+++ b/pwa/src/lib/Dashboard.svelte
@@ -15,6 +15,7 @@
     import Modal from "./Modal.svelte";
 
     import DBInfo from "./DBInfo.svelte";
+    import PasswordGenerator from "./PasswordGenerator.svelte";
 
     const dispatch = createEventDispatcher();
 
@@ -32,6 +33,15 @@
 
     let isDirty = false;
 
+    let generator;
+    let genClickCount = 0;
+    let showGenOptions = false;
+
+    function handleGenerate() {
+        genClickCount++;
+        generator.generate();
+        if (genClickCount >= 2) showGenOptions = true;
+    }
     let showModal = false;
     let modalConfig = {
         title: "",
@@ -162,6 +172,8 @@
             oldTitle = rec.Title; // Store original title
             showPassword = false;
             isNewRecord = false;
+            genClickCount = 0;
+            showGenOptions = false;
         } catch (e) {
             console.error(e);
             alert("Failed to load record details");
@@ -185,6 +197,8 @@
         oldTitle = "";
         showPassword = true;
         isNewRecord = true;
+        genClickCount = 0;
+        showGenOptions = false;
     }
 
     // Bind this to the new record event from the menu
@@ -673,6 +687,7 @@
                         <button on:click={() => (showPassword = !showPassword)}>
                             {showPassword ? "Hide" : "Show"}
                         </button>
+                        <button on:click={handleGenerate}>Generate</button>
                         <button
                             class="icon-btn"
                             on:click={() =>
@@ -709,6 +724,14 @@
                         {/if}
                     </div>
                 </div>
+                <PasswordGenerator
+                    bind:this={generator}
+                    bind:showOptions={showGenOptions}
+                    on:generate={(e) => {
+                        selectedRecord.Password = e.detail;
+                        showPassword = true;
+                    }}
+                />
                 <div class="field">
                     <label>URL</label>
                     <div class="field-row">

--- a/pwa/src/lib/Dashboard.svelte
+++ b/pwa/src/lib/Dashboard.svelte
@@ -687,7 +687,14 @@
                         <button on:click={() => (showPassword = !showPassword)}>
                             {showPassword ? "Hide" : "Show"}
                         </button>
-                        <button on:click={handleGenerate}>Generate</button>
+                        <button class="generate-btn" on:click={handleGenerate}>
+                            <span class="generate-text">Generate</span>
+                            <svg class="generate-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect width="18" height="18" x="3" y="3" rx="2" ry="2"/>
+                                <path d="M16 8h.01"/><path d="M8 8h.01"/><path d="M8 16h.01"/>
+                                <path d="M16 16h.01"/><path d="M12 12h.01"/>
+                            </svg>
+                        </button>
                         <button
                             class="icon-btn"
                             on:click={() =>
@@ -861,7 +868,10 @@
         font-size: 1.5rem;
         cursor: pointer;
     }
+    .generate-icon { display: none; }
     @media (max-width: 768px) {
+        .generate-text { display: none; }
+        .generate-icon { display: inline-flex; align-items: center; vertical-align: middle; }
         .sidebar {
             width: 100%;
             height: 100vh;

--- a/pwa/src/lib/PasswordGenerator.svelte
+++ b/pwa/src/lib/PasswordGenerator.svelte
@@ -274,6 +274,12 @@
         border: 1px solid #3a3a3a;
         background: #1e1e1e;
         color: #555;
+        transition: transform 0.08s ease;
+        position: relative;
+    }
+    .char-btn:hover {
+        transform: scale(2.5);
+        z-index: 10;
     }
     .char-btn.char-on {
         background: #3c3c3c;

--- a/pwa/src/lib/PasswordGenerator.svelte
+++ b/pwa/src/lib/PasswordGenerator.svelte
@@ -257,19 +257,25 @@
         display: flex;
         border: 1px solid #555;
         border-radius: 3px;
-        overflow: hidden;
     }
     .state-btn {
         background: none;
         border: none;
         border-right: 1px solid #555;
+        border-radius: 0;
         color: #666;
         font-size: 0.72em;
+        font-weight: 500;
         padding: 3px 9px;
         cursor: pointer;
+        white-space: nowrap;
+    }
+    .state-btn:first-child {
+        border-radius: 2px 0 0 2px;
     }
     .state-btn:last-child {
         border-right: none;
+        border-radius: 0 2px 2px 0;
     }
     .state-btn:hover:not(.active) {
         background: #3a3a3a;
@@ -277,17 +283,15 @@
     }
     .state-btn.state-required.active {
         background: #1a3a1a;
-        color: #4caf50;
-        font-weight: bold;
+        color: #5cca60;
     }
     .state-btn.state-included.active {
-        background: #3a3a3a;
-        color: #e0e0e0;
+        background: #2d2d2d;
+        color: #d0d0d0;
     }
     .state-btn.state-excluded.active {
         background: #3a1a1a;
-        color: #e05555;
-        font-weight: bold;
+        color: #ef6060;
     }
     .exclude-row {
         display: flex;

--- a/pwa/src/lib/PasswordGenerator.svelte
+++ b/pwa/src/lib/PasswordGenerator.svelte
@@ -197,6 +197,7 @@
         padding: 8px 10px;
         background: #2a2a2a;
         margin-top: 6px;
+        margin-bottom: 20px;
     }
     .panel-header {
         display: flex;

--- a/pwa/src/lib/PasswordGenerator.svelte
+++ b/pwa/src/lib/PasswordGenerator.svelte
@@ -116,7 +116,7 @@
 {#if showOptions}
 <div class="pwgen-panel">
     <div class="panel-header">
-        <span class="panel-title">Generation options</span>
+        <span class="panel-title">Enabled characters</span>
         <label class="length-label">
             Length
             <input
@@ -290,7 +290,6 @@
         background: #1e1e1e;
         border-color: #333;
         color: #444;
-        text-decoration: line-through;
     }
     .char-btn:disabled {
         cursor: not-allowed;

--- a/pwa/src/lib/PasswordGenerator.svelte
+++ b/pwa/src/lib/PasswordGenerator.svelte
@@ -298,4 +298,7 @@
         background: #2a2a2a;
         border-color: #555;
     }
+    @media (max-width: 768px) {
+        .chars { display: none; }
+    }
 </style>

--- a/pwa/src/lib/PasswordGenerator.svelte
+++ b/pwa/src/lib/PasswordGenerator.svelte
@@ -1,5 +1,6 @@
 <script>
     import { createEventDispatcher } from 'svelte';
+    import { slide } from 'svelte/transition';
     const dispatch = createEventDispatcher();
 
     export let showOptions = false;
@@ -136,7 +137,7 @@
 </script>
 
 {#if showOptions}
-<div class="pwgen-panel">
+<div class="pwgen-panel" transition:slide={{ duration: 200 }}>
     <div class="panel-header">
         <span class="panel-title">Password options</span>
         <label class="length-label">
@@ -152,7 +153,6 @@
             />
         </label>
         <button class="reset-btn" on:click={reset} title="Reset to defaults">↺ Reset</button>
-        <button class="collapse-btn" on:click={() => (showOptions = false)} title="Hide options">▲</button>
     </div>
 
     {#each GROUPS as g}
@@ -240,18 +240,6 @@
     .reset-btn:hover {
         color: #ccc;
         border-color: #888;
-    }
-    .collapse-btn {
-        background: none;
-        border: none;
-        color: #666;
-        cursor: pointer;
-        font-size: 0.75em;
-        padding: 2px 4px;
-        line-height: 1;
-    }
-    .collapse-btn:hover {
-        color: #ccc;
     }
     .group {
         display: flex;

--- a/pwa/src/lib/PasswordGenerator.svelte
+++ b/pwa/src/lib/PasswordGenerator.svelte
@@ -4,27 +4,28 @@
 
     export let showOptions = false;
 
-    const SYMBOL_CHARS = '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'.split('');
-    const SYMBOL_DEFAULT_OFF = new Set(['"', "'", '<', '>', '\\', '`']);
+    const DEFAULT_EXCLUDED = "\"'<>\\`";
 
     const GROUPS = [
         { id: 'upper',   label: 'A–Z',     chars: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('') },
         { id: 'lower',   label: 'a–z',     chars: 'abcdefghijklmnopqrstuvwxyz'.split('') },
         { id: 'digits',  label: '0–9',     chars: '0123456789'.split('') },
-        { id: 'symbols', label: 'Symbols', chars: SYMBOL_CHARS },
+        { id: 'symbols', label: 'Symbols', chars: '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'.split('') },
     ];
 
+    const VALID_STATES = new Set(['required', 'included', 'excluded']);
+
     function makeDefault() {
-        const groups = {};
-        for (const g of GROUPS) {
-            groups[g.id] = {
-                state: (g.id === 'upper' || g.id === 'lower') ? 'require' : 'allow',
-                chars: Object.fromEntries(
-                    g.chars.map(c => [c, g.id !== 'symbols' || !SYMBOL_DEFAULT_OFF.has(c)])
-                ),
-            };
-        }
-        return { length: 20, groups };
+        return {
+            length: 20,
+            excludedChars: DEFAULT_EXCLUDED,
+            groups: {
+                upper:   { state: 'required' },
+                lower:   { state: 'required' },
+                digits:  { state: 'included' },
+                symbols: { state: 'included' },
+            }
+        };
     }
 
     function load() {
@@ -32,39 +33,36 @@
             const raw = localStorage.getItem('pwgen');
             if (raw) {
                 const p = JSON.parse(raw);
-                if (typeof p.length !== 'number') return makeDefault();
-                for (const g of GROUPS) {
-                    if (!p.groups?.[g.id]) {
-                        p.groups[g.id] = makeDefault().groups[g.id];
-                    } else {
-                        for (const c of g.chars) {
-                            if (!(c in p.groups[g.id].chars)) {
-                                p.groups[g.id].chars[c] = !SYMBOL_DEFAULT_OFF.has(c);
-                            }
+                if (typeof p.length === 'number' && typeof p.excludedChars === 'string') {
+                    for (const g of GROUPS) {
+                        if (!p.groups?.[g.id] || !VALID_STATES.has(p.groups[g.id].state)) {
+                            return makeDefault();
                         }
                     }
+                    return p;
                 }
-                return p;
             }
         } catch (_) {}
         return makeDefault();
     }
 
     let s = load();
+    let error = '';
 
     function persist() {
         localStorage.setItem('pwgen', JSON.stringify(s));
     }
 
-    function setGroupState(id, state) {
-        s.groups[id].state = state;
-        s = s;
+    function reset() {
+        s = makeDefault();
+        error = '';
         persist();
     }
 
-    function toggleChar(id, c) {
-        s.groups[id].chars[c] = !s.groups[id].chars[c];
+    function setGroupState(id, state) {
+        s.groups[id].state = state;
         s = s;
+        error = '';
         persist();
     }
 
@@ -78,6 +76,23 @@
         }
     }
 
+    function updateExcluded(e) {
+        const seen = new Set();
+        const filtered = [];
+        for (const c of e.target.value) {
+            const code = c.charCodeAt(0);
+            if (code >= 0x21 && code <= 0x7E && !seen.has(c)) {
+                seen.add(c);
+                filtered.push(c);
+            }
+        }
+        s.excludedChars = filtered.join('');
+        e.target.value = s.excludedChars;
+        s = s;
+        error = '';
+        persist();
+    }
+
     function randInt(max) {
         const arr = new Uint32Array(1);
         const limit = Math.floor(0x100000000 / max) * max;
@@ -87,19 +102,26 @@
     }
 
     export function generate() {
+        error = '';
+        const excluded = new Set(s.excludedChars);
         let pool = [];
         let guaranteed = [];
+
         for (const g of GROUPS) {
             const gs = s.groups[g.id];
-            if (gs.state === 'off') continue;
-            const active = g.chars.filter(c => gs.chars[c]);
+            if (gs.state === 'excluded') continue;
+            const active = g.chars.filter(c => !excluded.has(c));
             if (!active.length) continue;
             pool.push(...active);
-            if (gs.state === 'require') {
+            if (gs.state === 'required') {
                 guaranteed.push(active[randInt(active.length)]);
             }
         }
-        if (!pool.length) return;
+
+        if (!pool.length) {
+            error = 'No characters available — adjust settings';
+            return;
+        }
 
         const len = s.length;
         const result = guaranteed.slice(0, len);
@@ -116,7 +138,7 @@
 {#if showOptions}
 <div class="pwgen-panel">
     <div class="panel-header">
-        <span class="panel-title">Enabled characters</span>
+        <span class="panel-title">Password options</span>
         <label class="length-label">
             Length
             <input
@@ -129,38 +151,42 @@
                 class="length-input"
             />
         </label>
+        <button class="reset-btn" on:click={reset} title="Reset to defaults">↺ Reset</button>
         <button class="collapse-btn" on:click={() => (showOptions = false)} title="Hide options">▲</button>
     </div>
 
     {#each GROUPS as g}
         {@const gs = s.groups[g.id]}
-        <div class="group" class:group-off={gs.state === 'off'}>
-            <div class="group-header">
-                <span class="group-label">{g.label}</span>
-                <div class="state-bar">
-                    {#each ['require', 'allow', 'off'] as state}
-                        <button
-                            class="state-btn"
-                            class:active={gs.state === state}
-                            on:click={() => setGroupState(g.id, state)}
-                        >{state}</button>
-                    {/each}
-                </div>
-            </div>
-            <div class="chars">
-                {#each g.chars as c}
+        <div class="group">
+            <span class="group-label">{g.label}</span>
+            <div class="state-bar">
+                {#each ['required', 'included', 'excluded'] as state}
                     <button
-                        class="char-btn"
-                        class:char-on={gs.chars[c] && gs.state !== 'off'}
-                        class:char-off={!gs.chars[c] && gs.state !== 'off'}
-                        disabled={gs.state === 'off'}
-                        on:click={() => toggleChar(g.id, c)}
-                        title={gs.chars[c] ? 'Click to exclude' : 'Click to include'}
-                    >{c}</button>
+                        class="state-btn state-{state}"
+                        class:active={gs.state === state}
+                        on:click={() => setGroupState(g.id, state)}
+                    >{state}</button>
                 {/each}
             </div>
         </div>
     {/each}
+
+    <div class="exclude-row">
+        <label class="exclude-label" for="exclude-input">Excluded</label>
+        <input
+            id="exclude-input"
+            class="exclude-input"
+            type="text"
+            value={s.excludedChars}
+            on:input={updateExcluded}
+            spellcheck="false"
+            autocomplete="off"
+        />
+    </div>
+
+    {#if error}
+        <div class="error-msg">{error}</div>
+    {/if}
 </div>
 {/if}
 
@@ -175,7 +201,7 @@
     .panel-header {
         display: flex;
         align-items: center;
-        gap: 12px;
+        gap: 10px;
         margin-bottom: 8px;
     }
     .panel-title {
@@ -201,6 +227,20 @@
         text-align: center;
         font-size: 0.85em;
     }
+    .reset-btn {
+        background: none;
+        border: 1px solid #555;
+        color: #888;
+        cursor: pointer;
+        font-size: 0.72em;
+        padding: 2px 7px;
+        border-radius: 3px;
+        line-height: 1.4;
+    }
+    .reset-btn:hover {
+        color: #ccc;
+        border-color: #888;
+    }
     .collapse-btn {
         background: none;
         border: none;
@@ -214,19 +254,16 @@
         color: #ccc;
     }
     .group {
-        margin-bottom: 6px;
-    }
-    .group-header {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        margin-bottom: 3px;
+        margin-bottom: 5px;
     }
     .group-label {
-        font-size: 0.75em;
-        color: #888;
+        font-size: 0.8em;
+        color: #aaa;
         font-weight: bold;
-        min-width: 48px;
+        min-width: 52px;
     }
     .state-bar {
         display: flex;
@@ -238,72 +275,63 @@
         background: none;
         border: none;
         border-right: 1px solid #555;
-        color: #888;
-        font-size: 0.7em;
-        padding: 2px 7px;
+        color: #666;
+        font-size: 0.72em;
+        padding: 3px 9px;
         cursor: pointer;
-        text-transform: capitalize;
     }
     .state-btn:last-child {
         border-right: none;
     }
-    .state-btn.active {
-        background: #555;
-        color: #fff;
-    }
     .state-btn:hover:not(.active) {
         background: #3a3a3a;
-        color: #ccc;
+        color: #aaa;
     }
-    .chars {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 3px;
+    .state-btn.state-required.active {
+        background: #1a3a1a;
+        color: #4caf50;
+        font-weight: bold;
     }
-    .char-btn {
-        width: 22px;
-        height: 22px;
-        font-size: 0.78em;
-        font-family: monospace;
-        padding: 0;
-        border-radius: 3px;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border: 1px solid #3a3a3a;
-        background: #1e1e1e;
-        color: #555;
-        transition: transform 0.08s ease;
-        position: relative;
-    }
-    .char-btn:hover {
-        transform: scale(2.5);
-        z-index: 10;
-    }
-    .char-btn.char-on {
-        background: #3c3c3c;
-        border-color: #666;
+    .state-btn.state-included.active {
+        background: #3a3a3a;
         color: #e0e0e0;
     }
-    .char-btn.char-off {
-        background: #1e1e1e;
-        border-color: #333;
-        color: #444;
+    .state-btn.state-excluded.active {
+        background: #3a1a1a;
+        color: #e05555;
+        font-weight: bold;
     }
-    .char-btn:disabled {
-        cursor: not-allowed;
-        opacity: 0.35;
+    .exclude-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 7px;
     }
-    .char-btn:not(:disabled).char-on:hover {
-        background: #505050;
-        border-color: #888;
+    .exclude-label {
+        font-size: 0.75em;
+        color: #e05555;
+        font-weight: bold;
+        min-width: 52px;
     }
-    .char-btn:not(:disabled).char-off:hover {
-        background: #2a2a2a;
-        border-color: #555;
+    .exclude-input {
+        flex: 1;
+        background: #2a1a1a;
+        border: 1px solid #7a3333;
+        color: #e05555;
+        border-radius: 4px;
+        padding: 3px 6px;
+        font-family: monospace;
+        font-size: 0.85em;
+        letter-spacing: 0.08em;
     }
-    @media (max-width: 768px) {
-        .chars { display: none; }
+    .exclude-input:focus {
+        outline: none;
+        border-color: #e05555;
+    }
+    .error-msg {
+        margin-top: 6px;
+        font-size: 0.75em;
+        color: #e05555;
+        text-align: center;
     }
 </style>

--- a/pwa/src/lib/PasswordGenerator.svelte
+++ b/pwa/src/lib/PasswordGenerator.svelte
@@ -1,0 +1,301 @@
+<script>
+    import { createEventDispatcher } from 'svelte';
+    const dispatch = createEventDispatcher();
+
+    export let showOptions = false;
+
+    const SYMBOL_CHARS = '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'.split('');
+    const SYMBOL_DEFAULT_OFF = new Set(['"', "'", '<', '>', '\\', '`']);
+
+    const GROUPS = [
+        { id: 'upper',   label: 'A–Z',     chars: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('') },
+        { id: 'lower',   label: 'a–z',     chars: 'abcdefghijklmnopqrstuvwxyz'.split('') },
+        { id: 'digits',  label: '0–9',     chars: '0123456789'.split('') },
+        { id: 'symbols', label: 'Symbols', chars: SYMBOL_CHARS },
+    ];
+
+    function makeDefault() {
+        const groups = {};
+        for (const g of GROUPS) {
+            groups[g.id] = {
+                state: (g.id === 'upper' || g.id === 'lower') ? 'require' : 'allow',
+                chars: Object.fromEntries(
+                    g.chars.map(c => [c, g.id !== 'symbols' || !SYMBOL_DEFAULT_OFF.has(c)])
+                ),
+            };
+        }
+        return { length: 20, groups };
+    }
+
+    function load() {
+        try {
+            const raw = localStorage.getItem('pwgen');
+            if (raw) {
+                const p = JSON.parse(raw);
+                if (typeof p.length !== 'number') return makeDefault();
+                for (const g of GROUPS) {
+                    if (!p.groups?.[g.id]) {
+                        p.groups[g.id] = makeDefault().groups[g.id];
+                    } else {
+                        for (const c of g.chars) {
+                            if (!(c in p.groups[g.id].chars)) {
+                                p.groups[g.id].chars[c] = !SYMBOL_DEFAULT_OFF.has(c);
+                            }
+                        }
+                    }
+                }
+                return p;
+            }
+        } catch (_) {}
+        return makeDefault();
+    }
+
+    let s = load();
+
+    function persist() {
+        localStorage.setItem('pwgen', JSON.stringify(s));
+    }
+
+    function setGroupState(id, state) {
+        s.groups[id].state = state;
+        s = s;
+        persist();
+    }
+
+    function toggleChar(id, c) {
+        s.groups[id].chars[c] = !s.groups[id].chars[c];
+        s = s;
+        persist();
+    }
+
+    function updateLength(e) {
+        const v = parseInt(e.target.value, 10);
+        if (v >= 4 && v <= 64) {
+            s.length = v;
+            persist();
+        } else {
+            e.target.value = Math.min(64, Math.max(4, v || 4));
+        }
+    }
+
+    function randInt(max) {
+        const arr = new Uint32Array(1);
+        const limit = Math.floor(0x100000000 / max) * max;
+        let r;
+        do { crypto.getRandomValues(arr); r = arr[0]; } while (r >= limit);
+        return r % max;
+    }
+
+    export function generate() {
+        let pool = [];
+        let guaranteed = [];
+        for (const g of GROUPS) {
+            const gs = s.groups[g.id];
+            if (gs.state === 'off') continue;
+            const active = g.chars.filter(c => gs.chars[c]);
+            if (!active.length) continue;
+            pool.push(...active);
+            if (gs.state === 'require') {
+                guaranteed.push(active[randInt(active.length)]);
+            }
+        }
+        if (!pool.length) return;
+
+        const len = s.length;
+        const result = guaranteed.slice(0, len);
+        while (result.length < len) result.push(pool[randInt(pool.length)]);
+
+        for (let i = result.length - 1; i > 0; i--) {
+            const j = randInt(i + 1);
+            [result[i], result[j]] = [result[j], result[i]];
+        }
+        dispatch('generate', result.join(''));
+    }
+</script>
+
+{#if showOptions}
+<div class="pwgen-panel">
+    <div class="panel-header">
+        <span class="panel-title">Generation options</span>
+        <label class="length-label">
+            Length
+            <input
+                type="number"
+                min="4"
+                max="64"
+                value={s.length}
+                on:change={updateLength}
+                on:blur={updateLength}
+                class="length-input"
+            />
+        </label>
+        <button class="collapse-btn" on:click={() => (showOptions = false)} title="Hide options">▲</button>
+    </div>
+
+    {#each GROUPS as g}
+        {@const gs = s.groups[g.id]}
+        <div class="group" class:group-off={gs.state === 'off'}>
+            <div class="group-header">
+                <span class="group-label">{g.label}</span>
+                <div class="state-bar">
+                    {#each ['require', 'allow', 'off'] as state}
+                        <button
+                            class="state-btn"
+                            class:active={gs.state === state}
+                            on:click={() => setGroupState(g.id, state)}
+                        >{state}</button>
+                    {/each}
+                </div>
+            </div>
+            <div class="chars">
+                {#each g.chars as c}
+                    <button
+                        class="char-btn"
+                        class:char-on={gs.chars[c] && gs.state !== 'off'}
+                        class:char-off={!gs.chars[c] && gs.state !== 'off'}
+                        disabled={gs.state === 'off'}
+                        on:click={() => toggleChar(g.id, c)}
+                        title={gs.chars[c] ? 'Click to exclude' : 'Click to include'}
+                    >{c}</button>
+                {/each}
+            </div>
+        </div>
+    {/each}
+</div>
+{/if}
+
+<style>
+    .pwgen-panel {
+        border: 1px solid #444;
+        border-radius: 4px;
+        padding: 8px 10px;
+        background: #2a2a2a;
+        margin-top: 6px;
+    }
+    .panel-header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 8px;
+    }
+    .panel-title {
+        font-size: 0.75em;
+        color: #888;
+        font-weight: bold;
+        flex: 1;
+    }
+    .length-label {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        color: #ccc;
+        font-size: 0.85em;
+    }
+    .length-input {
+        width: 52px;
+        padding: 3px;
+        background: #333;
+        border: 1px solid #555;
+        color: #fff;
+        border-radius: 4px;
+        text-align: center;
+        font-size: 0.85em;
+    }
+    .collapse-btn {
+        background: none;
+        border: none;
+        color: #666;
+        cursor: pointer;
+        font-size: 0.75em;
+        padding: 2px 4px;
+        line-height: 1;
+    }
+    .collapse-btn:hover {
+        color: #ccc;
+    }
+    .group {
+        margin-bottom: 6px;
+    }
+    .group-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 3px;
+    }
+    .group-label {
+        font-size: 0.75em;
+        color: #888;
+        font-weight: bold;
+        min-width: 48px;
+    }
+    .state-bar {
+        display: flex;
+        border: 1px solid #555;
+        border-radius: 3px;
+        overflow: hidden;
+    }
+    .state-btn {
+        background: none;
+        border: none;
+        border-right: 1px solid #555;
+        color: #888;
+        font-size: 0.7em;
+        padding: 2px 7px;
+        cursor: pointer;
+        text-transform: capitalize;
+    }
+    .state-btn:last-child {
+        border-right: none;
+    }
+    .state-btn.active {
+        background: #555;
+        color: #fff;
+    }
+    .state-btn:hover:not(.active) {
+        background: #3a3a3a;
+        color: #ccc;
+    }
+    .chars {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 3px;
+    }
+    .char-btn {
+        width: 22px;
+        height: 22px;
+        font-size: 0.78em;
+        font-family: monospace;
+        padding: 0;
+        border-radius: 3px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid #3a3a3a;
+        background: #1e1e1e;
+        color: #555;
+    }
+    .char-btn.char-on {
+        background: #3c3c3c;
+        border-color: #666;
+        color: #e0e0e0;
+    }
+    .char-btn.char-off {
+        background: #1e1e1e;
+        border-color: #333;
+        color: #444;
+        text-decoration: line-through;
+    }
+    .char-btn:disabled {
+        cursor: not-allowed;
+        opacity: 0.35;
+    }
+    .char-btn:not(:disabled).char-on:hover {
+        background: #505050;
+        border-color: #888;
+    }
+    .char-btn:not(:disabled).char-off:hover {
+        background: #2a2a2a;
+        border-color: #555;
+    }
+</style>

--- a/pwa/tests/password_generator.spec.ts
+++ b/pwa/tests/password_generator.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const threeDbPath = path.resolve(__dirname, '../../pwsafe/test_dbs/three.dat');
+
+// three.dat contents (password: "three3#;"):
+//   "three entry 1"  group="group1"   user="three1_user"  pass="three1!@$%^&*()"  url="http://group1.com"
+//   "three entry 2"  group="group2"   user="three2_user"  pass="three2_-+=\\|][}{';:"
+//   "three entry 3"  group="group 3"  user="three3_user"  pass=",./<>?`~0"        url="https://group3.com"
+
+async function openThreeDb(page) {
+    const buffer = fs.readFileSync(threeDbPath);
+    const data = [...buffer];
+    await page.addInitScript((fileData) => {
+        (window as any).showOpenFilePicker = async () => {
+            const blob = new Blob([new Uint8Array(fileData)], { type: 'application/octet-stream' });
+            const file = new File([blob], 'three.dat');
+            return [{
+                getFile: async () => file,
+                createWritable: async () => ({ write: async () => {}, close: async () => {} }),
+                name: 'three.dat',
+            }];
+        };
+    }, data);
+    await page.goto('/');
+    await page.getByText('Open Database File').click();
+    await page.getByPlaceholder('Password').fill('three3#;');
+    await page.getByRole('button', { name: 'Unlock' }).click();
+    await expect(page.getByPlaceholder('Search...')).toBeVisible();
+}
+
+test.describe('Password options panel', () => {
+
+    test('gear icon toggles the panel open and closed', async ({ page }) => {
+        await openThreeDb(page);
+        await page.locator('.tree li').first().click();
+        await expect(page.locator('.record-details')).toBeVisible();
+
+        const panel = page.locator('.pwgen-panel');
+        await expect(panel).not.toBeVisible();
+
+        await page.getByTitle('Generator options').click();
+        await expect(panel).toBeVisible();
+
+        await page.getByTitle('Generator options').click();
+        await expect(panel).not.toBeVisible();
+    });
+
+    test('Generate button produces a new password', async ({ page }) => {
+        await openThreeDb(page);
+        await page.locator('.tree li').first().click();
+
+        const passwordInput = page.locator('.record-details').getByPlaceholder('Password');
+        const before = await passwordInput.inputValue();
+
+        await page.getByTitle('Generator options').click();
+        await page.getByRole('button', { name: 'Generate' }).click();
+
+        const after = await passwordInput.inputValue();
+        expect(after).not.toBe(before);
+        expect(after.length).toBeGreaterThan(0);
+    });
+
+});


### PR DESCRIPTION
This PR is the first part of a set of PRs that split up a larger previous PR (https://github.com/tkuhlman/gopwsafe/pull/21)

Description of the password generator behavior:
  - **Generate button** sits in the password row next to Show/Hide; clicking it immediately generates a new password using `crypto.getRandomValues()`
  - **Options panel** is revealed by a gear icon button (⚙) next to Generate; the panel collapses when toggled again
  - **Character group controls** are three-way selectors (Required / Included / Excluded) for uppercase, lowercase, digits, and symbols
  - **Exclude box** is a free-form input to ban specific characters (e.g. ambiguous ones); defaults exclude "'\<>\` and fyi I intend to configure this for my own use with these additional characters: 1I|lO0
  - **Length control** configurable from 4 to 64 characters, default 20. 4 was chosen to allow one of each of the 4 characters classes in cases where all four classes are set to 'required'
  - Settings persist in localStorage across sessions
  - Includes Playwright tests for the gear icon toggle and password generation