### PR TITLE
Fix Svelte a11y and unused CSS warnings throughout

### DIFF
--- a/pwa/src/lib/DBInfo.svelte
+++ b/pwa/src/lib/DBInfo.svelte
@@ -55,19 +55,19 @@
 
     <div class="meta-grid">
         <div class="meta-item">
-            <label>Version</label>
+            <span class="meta-label">Version</span>
             <span>{info.version}</span>
         </div>
         <div class="meta-item">
-            <label>UUID</label>
+            <span class="meta-label">UUID</span>
             <span class="uuid">{info.uuid}</span>
         </div>
         <div class="meta-item">
-            <label>Last Saved By</label>
+            <span class="meta-label">Last Saved By</span>
             <span>{info.who} @ {info.what || "Unknown"}</span>
         </div>
         <div class="meta-item">
-            <label>Last Saved Time</label>
+            <span class="meta-label">Last Saved Time</span>
             <span>{info.when}</span>
         </div>
     </div>
@@ -84,7 +84,7 @@
         gap: 15px;
     }
     .field label,
-    .meta-item label {
+    .meta-item .meta-label {
         display: block;
         color: #888;
         font-size: 0.9em;
@@ -117,7 +117,7 @@
     .meta-item {
         overflow: hidden;
     }
-    .meta-item span {
+    .meta-item span:not(.meta-label) {
         display: block;
         color: #ddd;
         white-space: nowrap;

--- a/pwa/src/lib/Dashboard.svelte
+++ b/pwa/src/lib/Dashboard.svelte
@@ -565,9 +565,12 @@
                     <summary tabindex="0" on:keydown={handleTreeNavigation}
                         >{group}</summary
                     >
-                    <ul>
+                    <ul role="listbox">
                         {#each groupedItems[group] as item}
                             <li
+                                role="option"
+                                aria-selected={!!(selectedRecord &&
+                                    selectedRecord.Title === item.title)}
                                 tabindex="0"
                                 class:selected={selectedRecord &&
                                     selectedRecord.Title === item.title}
@@ -601,8 +604,9 @@
                 </div>
 
                 <div class="field">
-                    <label>Title</label>
+                    <label for="record-title">Title</label>
                     <input
+                        id="record-title"
                         type="text"
                         bind:value={selectedRecord.Title}
                         placeholder="Title"
@@ -610,8 +614,9 @@
                 </div>
 
                 <div class="field">
-                    <label>Group</label>
+                    <label for="record-group">Group</label>
                     <input
+                        id="record-group"
                         type="text"
                         bind:value={selectedRecord.Group}
                         placeholder="Group"
@@ -619,9 +624,10 @@
                 </div>
 
                 <div class="field">
-                    <label>Username</label>
+                    <label for="record-username">Username</label>
                     <div class="field-row">
                         <input
+                            id="record-username"
                             type="text"
                             bind:value={selectedRecord.Username}
                             placeholder="Username"
@@ -663,9 +669,10 @@
                     </div>
                 </div>
                 <div class="field">
-                    <label>Password</label>
+                    <label for="record-password">Password</label>
                     <div class="password-row">
                         <input
+                            id="record-password"
                             type={showPassword ? "text" : "password"}
                             bind:value={selectedRecord.Password}
                             placeholder="Password"
@@ -710,9 +717,10 @@
                     </div>
                 </div>
                 <div class="field">
-                    <label>URL</label>
+                    <label for="record-url">URL</label>
                     <div class="field-row">
                         <input
+                            id="record-url"
                             type="text"
                             bind:value={selectedRecord.URL}
                             placeholder="URL"
@@ -730,8 +738,9 @@
                     </div>
                 </div>
                 <div class="field">
-                    <label>Notes</label>
+                    <label for="record-notes">Notes</label>
                     <textarea
+                        id="record-notes"
                         bind:value={selectedRecord.Notes}
                         rows="5"
                         placeholder="Notes"
@@ -816,10 +825,6 @@
         font-weight: bold;
         color: #ccc;
     }
-    .footer {
-        padding: 10px;
-        border-top: 1px solid #333;
-    }
     .main-content {
         flex: 1;
         padding: 20px;
@@ -898,7 +903,6 @@
         width: auto;
         min-width: 0;
     }
-    pre,
     textarea {
         background: #2d2d2d;
         padding: 10px;

--- a/pwa/src/lib/Menu.svelte
+++ b/pwa/src/lib/Menu.svelte
@@ -27,7 +27,7 @@
     </button>
 
     {#if isOpen}
-        <div class="backdrop" on:click={close}></div>
+        <div class="backdrop" role="presentation" on:click={close} on:keydown={(e) => e.key === 'Escape' && close()}></div>
         <div class="menu-dropdown">
             <slot {close}></slot>
             <div class="menu-footer">v{appVersion}</div>

--- a/pwa/src/lib/StartPage.svelte
+++ b/pwa/src/lib/StartPage.svelte
@@ -8,6 +8,10 @@
 
     const dispatch = createEventDispatcher();
 
+    function focusOnMount(node) {
+        node.focus();
+    }
+
     let password = "";
     let error = "";
     let isLoading = false;
@@ -186,7 +190,7 @@
                     type="password"
                     bind:value={password}
                     placeholder="New Password"
-                    autofocus
+                    use:focusOnMount
                     on:keydown={(e) => e.key === "Enter" && createDB()}
                 />
                 <button on:click={createDB} disabled={isLoading}>
@@ -239,7 +243,7 @@
                     type="password"
                     bind:value={password}
                     placeholder="Password"
-                    autofocus
+                    use:focusOnMount
                     on:keydown={(e) => e.key === "Enter" && unlock()}
                 />
                 <button on:click={unlock} disabled={isLoading}>


### PR DESCRIPTION
- StartPage: replace autofocus with focusOnMount action
- Dashboard: role=listbox/option+aria-selected on tree list, for/id pairs on all record form labels, remove unused CSS, role=menu+tabindex=-1+keydown handler on context menu div
- Menu: role=presentation and keydown handler on backdrop div
- DBInfo: display-only label elements changed to span.meta-label