### PR TITLE
Add search to wasm and UX

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -196,6 +196,23 @@ func updateDBInfo(this js.Value, args []js.Value) interface{} {
 	return nil
 }
 
+func searchRecords(this js.Value, args []js.Value) interface{} {
+	if db == nil {
+		return "database not open"
+	}
+	if len(args) != 2 {
+		return "invalid arguments: expected (query, namesOnly)"
+	}
+	query := args[0].String()
+	namesOnly := args[1].Bool()
+	titles := db.Search(query, namesOnly)
+	jsonData, err := json.Marshal(titles)
+	if err != nil {
+		return fmt.Sprintf("json marshal error: %s", err)
+	}
+	return string(jsonData)
+}
+
 func main() {
 	c := make(chan struct{}, 0)
 
@@ -209,6 +226,7 @@ func main() {
 	js.Global().Set("updateRecord", js.FuncOf(updateRecord))
 	js.Global().Set("deleteRecord", js.FuncOf(deleteRecord))
 	js.Global().Set("updateDBInfo", js.FuncOf(updateDBInfo))
+	js.Global().Set("searchRecords", js.FuncOf(searchRecords))
 
 	fmt.Println("WASM initialized")
 	<-c

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -13,7 +13,7 @@ import (
 
 var db *pwsafe.V3
 
-func openDB(this js.Value, args []js.Value) interface{} {
+func openDB(this js.Value, args []js.Value) any {
 	if len(args) != 2 {
 		return "invalid arguments: expected (data, password)"
 	}
@@ -38,7 +38,7 @@ func openDB(this js.Value, args []js.Value) interface{} {
 	return nil // null means success
 }
 
-func getDBData(this js.Value, args []js.Value) interface{} {
+func getDBData(this js.Value, args []js.Value) any {
 	if db == nil {
 		return "database not open"
 	}
@@ -76,7 +76,7 @@ func getDBData(this js.Value, args []js.Value) interface{} {
 	return string(jsonData)
 }
 
-func getRecord(this js.Value, args []js.Value) interface{} {
+func getRecord(this js.Value, args []js.Value) any {
 	if db == nil {
 		return "database not open"
 	}
@@ -102,7 +102,7 @@ func getRecord(this js.Value, args []js.Value) interface{} {
 	return string(jsonData)
 }
 
-func createDatabase(this js.Value, args []js.Value) interface{} {
+func createDatabase(this js.Value, args []js.Value) any {
 	if len(args) != 1 {
 		return "invalid arguments: expected (password)"
 	}
@@ -113,7 +113,7 @@ func createDatabase(this js.Value, args []js.Value) interface{} {
 	return nil
 }
 
-func getDBInfo(this js.Value, args []js.Value) interface{} {
+func getDBInfo(this js.Value, args []js.Value) any {
 	if db == nil {
 		return "database not open"
 	}
@@ -179,7 +179,7 @@ func getDBInfo(this js.Value, args []js.Value) interface{} {
 	return string(jsonData)
 }
 
-func updateDBInfo(this js.Value, args []js.Value) interface{} {
+func updateDBInfo(this js.Value, args []js.Value) any {
 	if db == nil {
 		return "database not open"
 	}
@@ -196,7 +196,7 @@ func updateDBInfo(this js.Value, args []js.Value) interface{} {
 	return nil
 }
 
-func searchRecords(this js.Value, args []js.Value) interface{} {
+func searchRecords(this js.Value, args []js.Value) any {
 	if db == nil {
 		return "database not open"
 	}
@@ -286,7 +286,7 @@ func (dto *RecordDTO) toRecord() (pwsafe.Record, error) {
 	return r, nil
 }
 
-func saveDB(this js.Value, args []js.Value) interface{} {
+func saveDB(this js.Value, args []js.Value) any {
 	if db == nil {
 		return "database not open"
 	}
@@ -302,7 +302,7 @@ func saveDB(this js.Value, args []js.Value) interface{} {
 	return dst
 }
 
-func addRecord(this js.Value, args []js.Value) interface{} {
+func addRecord(this js.Value, args []js.Value) any {
 	if db == nil {
 		return "database not open"
 	}
@@ -320,7 +320,7 @@ func addRecord(this js.Value, args []js.Value) interface{} {
 	return nil
 }
 
-func updateRecord(this js.Value, args []js.Value) interface{} {
+func updateRecord(this js.Value, args []js.Value) any {
 	if db == nil {
 		return "database not open"
 	}
@@ -343,7 +343,7 @@ func updateRecord(this js.Value, args []js.Value) interface{} {
 	return nil
 }
 
-func deleteRecord(this js.Value, args []js.Value) interface{} {
+func deleteRecord(this js.Value, args []js.Value) any {
 	if db == nil {
 		return "database not open"
 	}

--- a/pwa/src/lib/Dashboard.svelte
+++ b/pwa/src/lib/Dashboard.svelte
@@ -10,6 +10,7 @@
         updateRecord,
         deleteRecord,
         getDatabaseData,
+        searchRecords,
     } from "../wasm.js";
     import Menu from "./Menu.svelte";
     import Modal from "./Modal.svelte";
@@ -35,6 +36,7 @@
     let items = [];
     let filteredItems = [];
     let searchTerm = "";
+    let searchNamesOnly = localStorage.getItem('searchNamesOnly') !== 'false';
     let selectedRecord = null;
     let oldTitle = ""; // Track for renames
     let showPassword = false;
@@ -164,25 +166,11 @@
     });
 
     function filterItems() {
-        console.log(
-            "filterItems called. searchTerm:",
-            searchTerm,
-            "Total items:",
-            items.length,
-        );
-        if (!searchTerm) {
+        if (!searchTerm.trim()) {
             filteredItems = items;
         } else {
-            const lower = searchTerm.toLowerCase();
-            filteredItems = items.filter(
-                (i) =>
-                    i.title.toLowerCase().includes(lower) ||
-                    i.group.toLowerCase().includes(lower),
-            );
-        }
-        console.log("Filtered items count:", filteredItems.length);
-        if (filteredItems.length === 0 && items.length > 0) {
-            console.log("First item title:", items[0].title);
+            const matchedTitles = new Set(searchRecords(searchTerm, searchNamesOnly));
+            filteredItems = items.filter(i => matchedTitles.has(i.title));
         }
         groupItems(filteredItems);
     }
@@ -586,7 +574,7 @@
             <input
                 bind:this={searchInput}
                 type="text"
-                placeholder="Search..."
+                placeholder={searchNamesOnly ? "Search names…" : "Search details…"}
                 bind:value={searchTerm}
                 on:input={filterItems}
                 on:keydown={(e) => {
@@ -623,6 +611,17 @@
                     }
                 }}
             />
+            <label class="scope-label">
+                <input
+                    type="checkbox"
+                    bind:checked={searchNamesOnly}
+                    on:change={() => {
+                        localStorage.setItem('searchNamesOnly', String(searchNamesOnly));
+                        filterItems();
+                    }}
+                />
+                Names only
+            </label>
         </div>
 
         <div class="tree">

--- a/pwa/src/wasm.js
+++ b/pwa/src/wasm.js
@@ -151,3 +151,11 @@ export function updateDBInfo(name, description) {
         throw new Error(err);
     }
 }
+
+export function searchRecords(query, namesOnly) {
+    const res = window.searchRecords(query, namesOnly);
+    if (typeof res === 'string' && res.startsWith("database not open")) {
+        throw new Error(res);
+    }
+    return JSON.parse(res);
+}

--- a/pwa/tests/interaction.spec.ts
+++ b/pwa/tests/interaction.spec.ts
@@ -70,7 +70,7 @@ test.describe('Database Interaction', () => {
         await page.getByRole('button', { name: 'Unlock' }).click();
 
         // Expect StartPage to disappear and Main interface to appear
-        await expect(page.getByPlaceholder('Search...')).toBeVisible();
+        await expect(page.getByPlaceholder(/Search/)).toBeVisible();
 
         // Check for groups in sidebar
         await expect(page.locator('.sidebar details summary').first()).toBeVisible();
@@ -98,7 +98,7 @@ test.describe('Database Interaction', () => {
         await expect(passwordInput).toHaveAttribute('type', 'password');
 
         // Test Search
-        const searchInput = page.getByPlaceholder('Search...');
+        const searchInput = page.getByPlaceholder(/Search/);
         await searchInput.fill(title?.trim() || 'xyz');
 
         // Should still see the item

--- a/pwa/tests/mobile.spec.ts
+++ b/pwa/tests/mobile.spec.ts
@@ -20,7 +20,7 @@ test('Mobile UI: Check layout and copy buttons', async ({ page }) => {
 
     // Wait for dashboard to load
     // We look for the search input which is always there
-    await expect(page.getByPlaceholder('Search...')).toBeVisible();
+    await expect(page.getByPlaceholder(/Search/)).toBeVisible();
 
     // Create a new record to see fields
     // Open menu again

--- a/pwa/tests/password_generator.spec.ts
+++ b/pwa/tests/password_generator.spec.ts
@@ -30,7 +30,7 @@ async function openThreeDb(page) {
     await page.getByText('Open Database File').click();
     await page.getByPlaceholder('Password').fill('three3#;');
     await page.getByRole('button', { name: 'Unlock' }).click();
-    await expect(page.getByPlaceholder('Search...')).toBeVisible();
+    await expect(page.getByPlaceholder(/Search/)).toBeVisible();
 }
 
 test.describe('Password options panel', () => {

--- a/pwa/tests/search.spec.ts
+++ b/pwa/tests/search.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const threeDbPath = path.resolve(__dirname, '../../pwsafe/test_dbs/three.dat');
+
+// three.dat contents (password: "three3#;"):
+//   "three entry 1"  group="group1"   user="three1_user"  url="http://group1.com"
+//   "three entry 2"  group="group2"   user="three2_user"
+//   "three entry 3"  group="group 3"  user="three3_user"  url="https://group3.com"
+
+async function openThreeDb(page) {
+    const buffer = fs.readFileSync(threeDbPath);
+    const data = [...buffer];
+    await page.addInitScript((fileData) => {
+        (window as any).showOpenFilePicker = async () => {
+            const blob = new Blob([new Uint8Array(fileData)], { type: 'application/octet-stream' });
+            const file = new File([blob], 'three.dat');
+            return [{
+                getFile: async () => file,
+                createWritable: async () => ({ write: async () => {}, close: async () => {} }),
+                name: 'three.dat',
+            }];
+        };
+    }, data);
+    await page.goto('/');
+    await page.getByText('Open Database File').click();
+    await page.getByPlaceholder('Password').fill('three3#;');
+    await page.getByRole('button', { name: 'Unlock' }).click();
+    await expect(page.getByPlaceholder(/Search/)).toBeVisible();
+}
+
+test.describe('Search', () => {
+
+    test('names only is the default', async ({ page }) => {
+        await openThreeDb(page);
+        await expect(page.getByLabel('Names only')).toBeChecked();
+    });
+
+    test('names-only search finds title matches', async ({ page }) => {
+        await openThreeDb(page);
+        await page.getByPlaceholder(/Search/).fill('entry 1');
+        await expect(page.locator('.tree li')).toHaveCount(1);
+        await expect(page.locator('.tree li')).toContainText('three entry 1');
+    });
+
+    test('names-only search finds group matches', async ({ page }) => {
+        await openThreeDb(page);
+        await page.getByPlaceholder(/Search/).fill('group2');
+        await expect(page.locator('.tree li')).toHaveCount(1);
+        await expect(page.locator('.tree li')).toContainText('three entry 2');
+    });
+
+    test('names-only search does not find username', async ({ page }) => {
+        await openThreeDb(page);
+        await page.getByPlaceholder(/Search/).fill('three1_user');
+        await expect(page.locator('.tree li')).toHaveCount(0);
+    });
+
+    test('names-only search does not find URL', async ({ page }) => {
+        await openThreeDb(page);
+        await page.getByPlaceholder(/Search/).fill('group1.com');
+        await expect(page.locator('.tree li')).toHaveCount(0);
+    });
+
+    test('AND search narrows results', async ({ page }) => {
+        await openThreeDb(page);
+        await page.getByPlaceholder(/Search/).fill('entry group1');
+        await expect(page.locator('.tree li')).toHaveCount(1);
+        await expect(page.locator('.tree li')).toContainText('three entry 1');
+    });
+
+    test('search details finds username', async ({ page }) => {
+        await openThreeDb(page);
+        await page.getByLabel('Names only').uncheck();
+        await page.getByPlaceholder(/Search/).fill('three1_user');
+        await expect(page.locator('.tree li')).toHaveCount(1);
+        await expect(page.locator('.tree li')).toContainText('three entry 1');
+    });
+
+    test('search details finds URL', async ({ page }) => {
+        await openThreeDb(page);
+        await page.getByLabel('Names only').uncheck();
+        await page.getByPlaceholder(/Search/).fill('group3.com');
+        await expect(page.locator('.tree li')).toHaveCount(1);
+        await expect(page.locator('.tree li')).toContainText('three entry 3');
+    });
+
+    test('search details AND search spans multiple fields', async ({ page }) => {
+        await openThreeDb(page);
+        await page.getByLabel('Names only').uncheck();
+        // "entry" matches title, "group1.com" matches URL — both must be true
+        await page.getByPlaceholder(/Search/).fill('entry group1.com');
+        await expect(page.locator('.tree li')).toHaveCount(1);
+        await expect(page.locator('.tree li')).toContainText('three entry 1');
+    });
+
+    test('unmatched term returns empty list', async ({ page }) => {
+        await openThreeDb(page);
+        await page.getByPlaceholder(/Search/).fill('zzznotfound');
+        await expect(page.locator('.tree li')).toHaveCount(0);
+    });
+
+});

--- a/pwa/tests/ui.spec.ts
+++ b/pwa/tests/ui.spec.ts
@@ -31,7 +31,7 @@ test.describe('UI Improvements', () => {
         // Should have empty tree
         await expect(page.locator('.sidebar')).toBeVisible();
         // search input check
-        await expect(page.getByPlaceholder('Search...')).toBeVisible();
+        await expect(page.getByPlaceholder(/Search/)).toBeVisible();
     });
 
     test('should have functioning dashboard menu', async ({ page }) => {
@@ -62,7 +62,7 @@ test.describe('UI Improvements', () => {
         // 1. Autofocus Check
         // Need to wait slightly for timeout
         await page.waitForTimeout(200);
-        await expect(page.getByPlaceholder('Search...')).toBeFocused();
+        await expect(page.getByPlaceholder(/Search/)).toBeFocused();
 
         // 2. DB Info Check
         await page.locator('.hamburger').click();
@@ -230,30 +230,30 @@ test.describe('UI Improvements', () => {
 
         // Wait for dashboard and initial autofocus
         await expect(page.locator('.sidebar')).toBeVisible();
-        await expect(page.getByPlaceholder('Search...')).toBeFocused();
+        await expect(page.getByPlaceholder(/Search/)).toBeFocused();
 
         // Blur search by clicking tree
         await page.locator('.tree').click();
-        await expect(page.getByPlaceholder('Search...')).not.toBeFocused();
+        await expect(page.getByPlaceholder(/Search/)).not.toBeFocused();
 
         // Press / to focus
         await page.keyboard.press('/');
-        await expect(page.getByPlaceholder('Search...')).toBeFocused();
+        await expect(page.getByPlaceholder(/Search/)).toBeFocused();
 
         // Type something
         await page.keyboard.type('old');
-        await expect(page.getByPlaceholder('Search...')).toHaveValue('old');
+        await expect(page.getByPlaceholder(/Search/)).toHaveValue('old');
 
         // Blur
         await page.locator('.tree').click();
-        await expect(page.getByPlaceholder('Search...')).not.toBeFocused();
+        await expect(page.getByPlaceholder(/Search/)).not.toBeFocused();
 
         // Press / to focus again
         await page.keyboard.press('/');
-        await expect(page.getByPlaceholder('Search...')).toBeFocused();
+        await expect(page.getByPlaceholder(/Search/)).toBeFocused();
 
         // Check selection covers "old"
-        const finalSelection = await page.getByPlaceholder('Search...').evaluate((el: HTMLInputElement) => ({
+        const finalSelection = await page.getByPlaceholder(/Search/).evaluate((el: HTMLInputElement) => ({
             start: el.selectionStart,
             end: el.selectionEnd,
             value: el.value
@@ -263,7 +263,7 @@ test.describe('UI Improvements', () => {
 
         // Verify typing overwrite
         await page.keyboard.type('new');
-        await expect(page.getByPlaceholder('Search...')).toHaveValue('new');
+        await expect(page.getByPlaceholder(/Search/)).toHaveValue('new');
 
     });
 
@@ -294,12 +294,12 @@ test.describe('UI Improvements', () => {
         await page.getByRole('button', { name: 'Unlock' }).click();
 
         // Search for a unique item
-        await page.getByPlaceholder('Search...').fill('three entry 1');
+        await page.getByPlaceholder(/Search/).fill('three entry 1');
         // Wait for filter to apply
         await expect(page.locator('.tree li')).toHaveCount(1);
 
         // Verify search is focused
-        await expect(page.getByPlaceholder('Search...')).toBeFocused();
+        await expect(page.getByPlaceholder(/Search/)).toBeFocused();
 
         // Press Enter
         await page.keyboard.press('Enter');
@@ -310,7 +310,7 @@ test.describe('UI Improvements', () => {
 
         // Verify input lost focus (Focus moves to close button or body)
         // Wait for potential async focus switch
-        await expect(page.getByPlaceholder('Search...')).not.toBeFocused({ timeout: 5000 });
+        await expect(page.getByPlaceholder(/Search/)).not.toBeFocused({ timeout: 5000 });
     });
 
     test('should navigate tree with keyboard', async ({ page }) => {
@@ -339,7 +339,7 @@ test.describe('UI Improvements', () => {
         await page.getByRole('button', { name: 'Unlock' }).click();
 
         // Search to start somewhere or just focus search then down
-        const search = page.getByPlaceholder('Search...');
+        const search = page.getByPlaceholder(/Search/);
 
         // Wait for tree to be populated and items to be rendered
         await expect(page.locator('.tree details summary').first()).toBeVisible();

--- a/pwsafe/db.go
+++ b/pwsafe/db.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -99,6 +100,37 @@ func (db V3) ListByGroup(group string) []string {
 	}
 	sort.Strings(entries)
 	return entries
+}
+
+// Search returns titles of records matching all whitespace-separated terms in query.
+// When namesOnly is true only title and group are searched; otherwise username,
+// URL, and notes are included. Password is never searched.
+func (db V3) Search(query string, namesOnly bool) []string {
+	terms := strings.Fields(strings.ToLower(query))
+	if len(terms) == 0 {
+		return db.List()
+	}
+	var results []string
+	for _, rec := range db.Records {
+		var hay string
+		if namesOnly {
+			hay = strings.ToLower(rec.Title + "\n" + rec.Group)
+		} else {
+			hay = strings.ToLower(rec.Title + "\n" + rec.Group + "\n" + rec.Username + "\n" + rec.URL + "\n" + rec.Notes)
+		}
+		match := true
+		for _, t := range terms {
+			if !strings.Contains(hay, t) {
+				match = false
+				break
+			}
+		}
+		if match {
+			results = append(results, rec.Title)
+		}
+	}
+	sort.Strings(results)
+	return results
 }
 
 // NeedsSave Returns true if the db has unsaved modifiations


### PR DESCRIPTION
This PR supercedes the JS-side search filtering from PR #21, implementing a Go/WASM  search endpoint.

**Go code** adds db.Search(query, namesOnly) to pwsafe/db.go and this runs inside the WASM module to avoid storing database contents in JS memory during a search.

**Search scopes**
  - **Names only** (default, persisted in localStorage): searches title and group
  - **Search details** (uncheck the toggle): searches title, group, username, URL, and notes fields
  - Password and email fields are excluded from search in both modes (among other fields that are excluded)

**matches multiple substrings** splits search input into multiple terms (space-delimited) and uses an AND condition to match all records that contain all substrings.

**UX** shows a checkbox for "Names only" beside the search input, with checkbox state persistent across sessions. Wraps to next line in case of narrow screens.

## Security                                                                                                        

The previous implementation cached all record data in a JavaScript object for client-side filtering, leaving the full database accessible to any browser extension with JS access. This implementation performs all filtering in Go/WASM — JS receives only the titles of matching entries, consistent with how the rest of the app handles record data.

## Tests

New `search.spec.ts` covers names-only defaults, title/group matches, username and URL excluded from names-only mode, AND logic, search details mode, cross-field AND, and empty results.