### PR TITLE
Add ghost-text autocomplete for Group and Username fields

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"syscall/js"
 	"time"
 
@@ -196,6 +198,56 @@ func updateDBInfo(this js.Value, args []js.Value) interface{} {
 	return nil
 }
 
+func getSuggestion(this js.Value, args []js.Value) interface{} {
+	if db == nil {
+		return ""
+	}
+	if len(args) != 2 {
+		return ""
+	}
+	field := args[0].String()
+	prefix := args[1].String()
+	if prefix == "" {
+		return ""
+	}
+
+	prefixLower := strings.ToLower(prefix)
+	freq := make(map[string]int)
+	for _, rec := range db.Records {
+		var val string
+		switch field {
+		case "group":
+			val = rec.Group
+		case "username":
+			val = rec.Username
+		default:
+			return ""
+		}
+		if val != "" {
+			freq[val]++
+		}
+	}
+
+	var matches []string
+	for val := range freq {
+		if strings.HasPrefix(strings.ToLower(val), prefixLower) {
+			matches = append(matches, val)
+		}
+	}
+	if len(matches) == 0 {
+		return ""
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		fi, fj := freq[matches[i]], freq[matches[j]]
+		if fi != fj {
+			return fi > fj
+		}
+		return strings.ToLower(matches[i]) < strings.ToLower(matches[j])
+	})
+	return matches[0]
+}
+
 func main() {
 	c := make(chan struct{}, 0)
 
@@ -209,6 +261,7 @@ func main() {
 	js.Global().Set("updateRecord", js.FuncOf(updateRecord))
 	js.Global().Set("deleteRecord", js.FuncOf(deleteRecord))
 	js.Global().Set("updateDBInfo", js.FuncOf(updateDBInfo))
+	js.Global().Set("getSuggestion", js.FuncOf(getSuggestion))
 
 	fmt.Println("WASM initialized")
 	<-c

--- a/pwa/src/lib/Dashboard.svelte
+++ b/pwa/src/lib/Dashboard.svelte
@@ -10,6 +10,7 @@
         updateRecord,
         deleteRecord,
         getDatabaseData,
+        getAutocompleteSuggestion,
     } from "../wasm.js";
     import Menu from "./Menu.svelte";
     import Modal from "./Modal.svelte";
@@ -31,6 +32,66 @@
     let isNewRecord = false;
 
     let isDirty = false;
+
+    let groupSuggestion = "";
+    let groupGhostSuffix = "";
+    let usernameSuggestion = "";
+    let usernameGhostSuffix = "";
+
+    function clearGhosts() {
+        groupSuggestion = "";
+        groupGhostSuffix = "";
+        usernameSuggestion = "";
+        usernameGhostSuffix = "";
+    }
+
+    function applySuggestion(field, value) {
+        const s = getAutocompleteSuggestion(field, value);
+        if (s && s.toLowerCase() !== value.toLowerCase()) {
+            return { suggestion: s, ghost: s.slice(value.length) };
+        }
+        return { suggestion: "", ghost: "" };
+    }
+
+    function onGroupInput() {
+        const v = selectedRecord.Group;
+        if (!v) { groupSuggestion = ""; groupGhostSuffix = ""; return; }
+        const r = applySuggestion("group", v);
+        groupSuggestion = r.suggestion;
+        groupGhostSuffix = r.ghost;
+    }
+
+    function onGroupKeydown(e) {
+        if (e.key === "Tab" && groupSuggestion) {
+            e.preventDefault();
+            selectedRecord = { ...selectedRecord, Group: groupSuggestion };
+            groupSuggestion = "";
+            groupGhostSuffix = "";
+        } else if (e.key === "Escape") {
+            groupSuggestion = "";
+            groupGhostSuffix = "";
+        }
+    }
+
+    function onUsernameInput() {
+        const v = selectedRecord.Username;
+        if (!v) { usernameSuggestion = ""; usernameGhostSuffix = ""; return; }
+        const r = applySuggestion("username", v);
+        usernameSuggestion = r.suggestion;
+        usernameGhostSuffix = r.ghost;
+    }
+
+    function onUsernameKeydown(e) {
+        if (e.key === "Tab" && usernameSuggestion) {
+            e.preventDefault();
+            selectedRecord = { ...selectedRecord, Username: usernameSuggestion };
+            usernameSuggestion = "";
+            usernameGhostSuffix = "";
+        } else if (e.key === "Escape") {
+            usernameSuggestion = "";
+            usernameGhostSuffix = "";
+        }
+    }
 
     let showModal = false;
     let modalConfig = {
@@ -162,6 +223,7 @@
             oldTitle = rec.Title; // Store original title
             showPassword = false;
             isNewRecord = false;
+            clearGhosts();
         } catch (e) {
             console.error(e);
             alert("Failed to load record details");
@@ -185,6 +247,7 @@
         oldTitle = "";
         showPassword = true;
         isNewRecord = true;
+        clearGhosts();
     }
 
     // Bind this to the new record event from the menu
@@ -611,21 +674,41 @@
 
                 <div class="field">
                     <label>Group</label>
-                    <input
-                        type="text"
-                        bind:value={selectedRecord.Group}
-                        placeholder="Group"
-                    />
+                    <div class="autocomplete-wrap">
+                        {#if groupGhostSuffix}
+                            <div class="ghost-overlay" aria-hidden="true">
+                                <span class="ghost-typed">{selectedRecord.Group}</span><span class="ghost-suffix">{groupGhostSuffix}</span>
+                            </div>
+                        {/if}
+                        <input
+                            type="text"
+                            bind:value={selectedRecord.Group}
+                            placeholder="Group"
+                            on:input={onGroupInput}
+                            on:keydown={onGroupKeydown}
+                            on:blur={() => { groupSuggestion = ""; groupGhostSuffix = ""; }}
+                        />
+                    </div>
                 </div>
 
                 <div class="field">
                     <label>Username</label>
                     <div class="field-row">
-                        <input
-                            type="text"
-                            bind:value={selectedRecord.Username}
-                            placeholder="Username"
-                        />
+                        <div class="autocomplete-wrap">
+                            {#if usernameGhostSuffix}
+                                <div class="ghost-overlay" aria-hidden="true">
+                                    <span class="ghost-typed">{selectedRecord.Username}</span><span class="ghost-suffix">{usernameGhostSuffix}</span>
+                                </div>
+                            {/if}
+                            <input
+                                type="text"
+                                bind:value={selectedRecord.Username}
+                                placeholder="Username"
+                                on:input={onUsernameInput}
+                                on:keydown={onUsernameKeydown}
+                                on:blur={() => { usernameSuggestion = ""; usernameGhostSuffix = ""; }}
+                            />
+                        </div>
                         <button
                             class="icon-btn"
                             on:click={() =>
@@ -984,5 +1067,41 @@
         100% {
             opacity: 0;
         }
+    }
+    .autocomplete-wrap {
+        position: relative;
+        display: block;
+    }
+    .autocomplete-wrap input {
+        width: 100%;
+    }
+    .field-row .autocomplete-wrap {
+        flex: 1;
+        min-width: 0;
+    }
+    .field-row .autocomplete-wrap input {
+        width: 100%;
+    }
+    .ghost-overlay {
+        position: absolute;
+        inset: 0;
+        padding: 8px;
+        pointer-events: none;
+        font-size: 1rem;
+        font-family: inherit;
+        line-height: 1.5;
+        white-space: pre;
+        overflow: hidden;
+        border: 1px solid transparent;
+        border-radius: 4px;
+        z-index: 1;
+        display: flex;
+        align-items: center;
+    }
+    .ghost-typed {
+        color: transparent;
+    }
+    .ghost-suffix {
+        color: #666;
     }
 </style>

--- a/pwa/src/wasm.js
+++ b/pwa/src/wasm.js
@@ -151,3 +151,7 @@ export function updateDBInfo(name, description) {
         throw new Error(err);
     }
 }
+
+export function getAutocompleteSuggestion(field, prefix) {
+    return window.getSuggestion(field, prefix) || "";
+}


### PR DESCRIPTION
Tab-completes the most frequent prefix-matching value from existing records. Suggestion is fetched one-at-a-time from the Go/WASM layer (getSuggestion) to avoid bulk-exposing credential metadata to JS.