### PR TITLE
Add opt-in UUID keying for db.Records to avoid dropping same-titled entries

### DIFF
--- a/pwsafe/db.go
+++ b/pwsafe/db.go
@@ -24,9 +24,26 @@ type V3 struct {
 	Iter          uint32 //the number of iterations on the hash function to create the stretched key
 	LastMod       time.Time
 	LastSavePath  string
-	Records       map[string]Record //the key is the record title
+	Records       map[string]Record //the key is the record title, or its hex-encoded UUID if KeyByUUID is set
 	Salt          [32]byte
 	StretchedKey  [sha256.Size]byte
+
+	// KeyByUUID controls how Records is keyed. Password Safe v3 only guarantees a
+	// record's UUID to be unique, not its Title, so a db containing multiple records
+	// with the same title (e.g. several "Google" entries) will have all but one of
+	// them silently overwritten in Records when keyed by Title (the default, kept
+	// for backwards compatibility). Set KeyByUUID to true, before Decrypt/SetRecord
+	// are called, to key Records by UUID instead and retain every record.
+	KeyByUUID bool
+}
+
+// recordKey returns the map key to use for storing/looking up a record in db.Records,
+// based on the current KeyByUUID setting.
+func (db *V3) recordKey(record Record) string {
+	if db.KeyByUUID {
+		return fmt.Sprintf("%x", record.UUID)
+	}
+	return record.Title
 }
 
 // NewV3 - create and initialize a new pwsafe.V3 db
@@ -40,10 +57,45 @@ func NewV3(name, password string) *V3 {
 	return &db
 }
 
-// DeleteRecord Removes a record from the db
+// DeleteRecord Removes a record from the db. When KeyByUUID is false (the default),
+// this removes the record keyed by this exact title. When KeyByUUID is true, titles
+// are not guaranteed unique, so this removes the first record found with a matching
+// title; use DeleteRecordByUUID for precise deletion in that case.
 func (db *V3) DeleteRecord(title string) {
-	delete(db.Records, title)
+	if db.KeyByUUID {
+		for key, record := range db.Records {
+			if record.Title == title {
+				delete(db.Records, key)
+				break
+			}
+		}
+	} else {
+		delete(db.Records, title)
+	}
 	db.LastMod = time.Now()
+}
+
+// DeleteRecordByUUID removes the record with the given UUID from the db, if present.
+// Only meaningful when KeyByUUID is true.
+func (db *V3) DeleteRecordByUUID(id [16]byte) {
+	delete(db.Records, fmt.Sprintf("%x", id))
+	db.LastMod = time.Now()
+}
+
+// RecordByTitle returns the first record found with a matching title. When KeyByUUID
+// is true, titles are not guaranteed unique, so if the db contains multiple records
+// sharing this title, which one gets returned is undefined.
+func (db V3) RecordByTitle(title string) (Record, bool) {
+	if !db.KeyByUUID {
+		record, prs := db.Records[title]
+		return record, prs
+	}
+	for _, record := range db.Records {
+		if record.Title == title {
+			return record, true
+		}
+	}
+	return Record{}, false
 }
 
 // Equal compares the content of two V3 DBs except for LastSave fields and fields with transient or changing values.
@@ -57,7 +109,12 @@ func (db *V3) Equal(other *V3) (bool, error) {
 		return false, fmt.Errorf("record lengths don't match, %v != %v", len(db.List()), len(other.List()))
 	}
 	for _, title := range db.List() {
-		equal, err := db.Records[title].Equal(other.Records[title], true)
+		record, _ := db.RecordByTitle(title)
+		otherRecord, prs := other.RecordByTitle(title)
+		if !prs {
+			return false, fmt.Errorf("record with title %q not found in other db", title)
+		}
+		equal, err := record.Equal(otherRecord, true)
 		if !equal {
 			return false, err
 		}
@@ -79,11 +136,12 @@ func (db V3) Groups() []string {
 	return groups
 }
 
-// List Returns the titles of all the records in the db.
+// List Returns the titles of all the records in the db. When KeyByUUID is true and the
+// db contains records sharing a title, that title is included once per such record.
 func (db V3) List() []string {
 	entries := make([]string, 0, len(db.Records))
-	for key := range db.Records {
-		entries = append(entries, key)
+	for _, value := range db.Records {
+		entries = append(entries, value.Title)
 	}
 	sort.Strings(entries)
 	return entries
@@ -92,9 +150,9 @@ func (db V3) List() []string {
 // ListByGroup Returns the list of record titles that have the given group.
 func (db V3) ListByGroup(group string) []string {
 	entries := make([]string, 0, len(db.Records))
-	for key, value := range db.Records {
+	for _, value := range db.Records {
 		if value.Group == group {
-			entries = append(entries, key)
+			entries = append(entries, value.Title)
 		}
 	}
 	sort.Strings(entries)
@@ -118,11 +176,23 @@ func (db *V3) SetPassword(pw string) error {
 	return nil
 }
 
-// SetRecord Adds or updates a record in the db
+// SetRecord Adds or updates a record in the db. When KeyByUUID is false (the default),
+// a record is recognized as an update to an existing one if it shares that record's
+// Title (the original, backwards-compatible behavior). When KeyByUUID is true, a
+// record is only recognized as an update if it carries the existing record's UUID;
+// records with no UUID set (the zero value) are always treated as new in that mode.
 func (db *V3) SetRecord(record Record) {
 	now := time.Now()
 	//detect if there have been changes and only update if needed
-	oldRecord, prs := db.Records[record.Title]
+	var oldRecord Record
+	var prs bool
+	if db.KeyByUUID {
+		if record.UUID != [16]byte{} {
+			oldRecord, prs = db.Records[db.recordKey(record)]
+		}
+	} else {
+		oldRecord, prs = db.Records[record.Title]
+	}
 	if prs {
 		equal, _ := oldRecord.Equal(record, false)
 		if equal {
@@ -140,7 +210,7 @@ func (db *V3) SetRecord(record Record) {
 		record.UUID = [16]byte(uuid.NewRandom().Array())
 	}
 	record.ModTime = now
-	db.Records[record.Title] = record
+	db.Records[db.recordKey(record)] = record
 	db.LastMod = now
 }
 

--- a/pwsafe/dbFile.go
+++ b/pwsafe/dbFile.go
@@ -2,9 +2,25 @@ package pwsafe
 
 import "os"
 
-//OpenPWSafeFile Opens a password safe v3 file and decrypts with the supplied password
+//OpenPWSafeFile Opens a password safe v3 file and decrypts with the supplied password.
+//Records is keyed by Title (see V3.KeyByUUID); use OpenPWSafeFileKeyedByUUID to key by
+//UUID instead, which retains every record in databases with duplicate titles.
 func OpenPWSafeFile(dbPath string, passwd string) (*V3, error) {
+	return openPWSafeFile(dbPath, passwd, false)
+}
+
+//OpenPWSafeFileKeyedByUUID Opens a password safe v3 file and decrypts with the supplied
+//password, keying the resulting V3.Records by UUID instead of Title. Password Safe v3
+//only guarantees UUID to be unique, not Title, so prefer this over OpenPWSafeFile when
+//the database may contain multiple records sharing a title (e.g. several "Google"
+//entries) to avoid having all but one of them silently dropped.
+func OpenPWSafeFileKeyedByUUID(dbPath string, passwd string) (*V3, error) {
+	return openPWSafeFile(dbPath, passwd, true)
+}
+
+func openPWSafeFile(dbPath string, passwd string, keyByUUID bool) (*V3, error) {
 	var db V3
+	db.KeyByUUID = keyByUUID
 
 	// Open the file
 	f, err := os.Open(dbPath)

--- a/pwsafe/db_test.go
+++ b/pwsafe/db_test.go
@@ -71,3 +71,49 @@ func TestSetRecordTimes(t *testing.T) {
 	assert.True(t, updatedRecord.ModTime.After(modTime))
 	assert.True(t, db.LastMod.After(dbLastMod))
 }
+
+// TestSetRecordKeyedByUUIDSameTitleDifferentUUID is a regression test ensuring that,
+// with KeyByUUID enabled, SetRecord treats records with the same Title but no matching
+// UUID as distinct entries, rather than overwriting one another (the default behavior
+// exercised by TestSetRecordTimes above, which stays keyed by Title for compatibility).
+func TestSetRecordKeyedByUUIDSameTitleDifferentUUID(t *testing.T) {
+	db := NewV3("test", "password")
+	db.KeyByUUID = true
+
+	db.SetRecord(Record{Title: "Google", Username: "user1", Password: "pass1"})
+	db.SetRecord(Record{Title: "Google", Username: "user2", Password: "pass2"})
+
+	assert.Equal(t, 2, len(db.Records), "both same-titled records should be kept as distinct entries")
+
+	usernames := make([]string, 0, 2)
+	for _, record := range db.Records {
+		usernames = append(usernames, record.Username)
+	}
+	assert.ElementsMatch(t, []string{"user1", "user2"}, usernames)
+}
+
+// TestDeleteRecordByUUID verifies precise, identity-based deletion when KeyByUUID is
+// enabled, which matters when multiple records share a Title and DeleteRecord's
+// title-based match would be ambiguous.
+func TestDeleteRecordByUUID(t *testing.T) {
+	db := NewV3("test", "password")
+	db.KeyByUUID = true
+
+	db.SetRecord(Record{Title: "Google", Username: "user1", Password: "pass1"})
+	db.SetRecord(Record{Title: "Google", Username: "user2", Password: "pass2"})
+	assert.Equal(t, 2, len(db.Records))
+
+	var target Record
+	for _, record := range db.Records {
+		if record.Username == "user2" {
+			target = record
+		}
+	}
+
+	db.DeleteRecordByUUID(target.UUID)
+	assert.Equal(t, 1, len(db.Records))
+
+	remaining, ok := db.RecordByTitle("Google")
+	assert.True(t, ok)
+	assert.NotEqual(t, target.UUID, remaining.UUID)
+}

--- a/pwsafe/decrypt.go
+++ b/pwsafe/decrypt.go
@@ -157,7 +157,7 @@ func (db *V3) unmarshalRecords(records []byte) (int, []byte, error) {
 	for recordStart < len(records) {
 		record := &Record{}
 		recordLength, recordData, err := unmarshalRecord(records[recordStart:], record)
-		db.Records[record.Title] = *record
+		db.Records[db.recordKey(*record)] = *record
 		if err != nil {
 			return recordStart, hmacData, errors.New("error parsing record - " + err.Error())
 		}

--- a/pwsafe/decrypt_test.go
+++ b/pwsafe/decrypt_test.go
@@ -490,3 +490,63 @@ func TestEdgeCases_ModifyDeleteAndNonExistent(t *testing.T) {
 	// DeleteRecord always updates LastMod, so NeedsSave will become true.
 	assert.True(t, dbNonExistent.NeedsSave(), "NeedsSave() should become true after DeleteRecord, even if record did not exist, due to LastMod update")
 }
+
+// TestDuplicateTitlesDefaultBehavior documents the existing, backwards-compatible default
+// behavior: when KeyByUUID is false (the default), db.Records is keyed by Title, so a db
+// containing multiple records that share a title (e.g. several "Google" entries) will have
+// all but one of them silently dropped, both in memory and across a save/reload round trip.
+func TestDuplicateTitlesDefaultBehavior(t *testing.T) {
+	db := NewV3("", "password")
+	dupPath := "./test_dbs/duplicate_titles_default_test.dat"
+	db.LastSavePath = dupPath
+
+	db.SetRecord(Record{Title: "Google", Username: "work.user@example.com", Password: "workpass", Group: "Work"})
+	db.SetRecord(Record{Title: "Google", Username: "personal.user@example.com", Password: "personalpass", Group: "Personal"})
+
+	// Only the most recently set record survives, since both share the "Google" map key.
+	assert.Equal(t, 1, len(db.Records), "default Title-keyed behavior only retains the last same-titled record")
+	record, ok := db.RecordByTitle("Google")
+	assert.True(t, ok)
+	assert.Equal(t, "personal.user@example.com", record.Username)
+
+	err := WritePWSafeFile(db, dupPath)
+	assert.Nil(t, err)
+	defer os.Remove(dupPath)
+
+	reopened, err := OpenPWSafeFile(dupPath, "password")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(reopened.Records), "duplicate title loss persists across a save/reload round trip")
+}
+
+// TestDuplicateTitlesKeyedByUUID is a regression test for the fix: when KeyByUUID is
+// true, db.Records is keyed by UUID instead of Title, so records sharing a title are
+// no longer dropped during SetRecord or Decrypt.
+func TestDuplicateTitlesKeyedByUUID(t *testing.T) {
+	db := NewV3("", "password")
+	db.KeyByUUID = true
+	dupPath := "./test_dbs/duplicate_titles_uuid_test.dat"
+	db.LastSavePath = dupPath
+
+	db.SetRecord(Record{Title: "Google", Username: "work.user@example.com", Password: "workpass", Group: "Work"})
+	db.SetRecord(Record{Title: "Google", Username: "personal.user@example.com", Password: "personalpass", Group: "Personal"})
+
+	assert.Equal(t, 2, len(db.Records), "both same-titled records should be retained")
+	assert.Equal(t, []string{"Google", "Google"}, db.List())
+
+	err := WritePWSafeFile(db, dupPath)
+	assert.Nil(t, err)
+	defer os.Remove(dupPath)
+
+	// Reopen keyed by UUID and verify decryption doesn't drop either "Google" entry.
+	reopened, err := OpenPWSafeFileKeyedByUUID(dupPath, "password")
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(reopened.Records), "both same-titled records should survive a save/reload round trip")
+	assert.Equal(t, []string{"Google", "Google"}, reopened.List())
+
+	usernames := make([]string, 0, 2)
+	for _, record := range reopened.Records {
+		assert.Equal(t, "Google", record.Title)
+		usernames = append(usernames, record.Username)
+	}
+	assert.ElementsMatch(t, []string{"work.user@example.com", "personal.user@example.com"}, usernames)
+}


### PR DESCRIPTION
## Summary

A back compat alternative to https://github.com/tkuhlman/gopwsafe/pull/36.

Password Safe v3 only guarantees a record's UUID to be unique, not its Title. `db.Records` was keyed by Title, so a db containing multiple records that share a title (e.g. several "foo" entries) would silently drop all but one of them, both during decryption and via `SetRecord`.

This adds an opt-in `V3.KeyByUUID` flag (default `false`, preserving existing behavior) that keys `Records` by UUID instead of Title when enabled.

## Changes

- New `V3.KeyByUUID` field and internal `recordKey()` helper
- `decrypt.go` and `SetRecord` key `Records` by UUID when `KeyByUUID` is true
- `SetRecord` only treats a record as an update to an existing one via UUID match when `KeyByUUID` is true, since `Title` is no longer the identity
- New `OpenPWSafeFileKeyedByUUID`, `DeleteRecordByUUID`, and `RecordByTitle` helpers
- `List`/`ListByGroup`/`Equal` now read `Record.Title` from map values rather than assuming the map key is always the title, so they behave correctly in both modes without changing default output
- Existing tests are unchanged and continue to pass against the default (Title-keyed) behavior; new tests cover `KeyByUUID` retaining/deleting same-titled records and surviving a save/reload round trip

Left the default as Title-keyed for backwards compatibility; happy to flip the default (or make this the only behavior) if that's preferred instead.
